### PR TITLE
fixed latex in _posts/2010-03-09-fokina10a.md: re-added double backslash

### DIFF
--- a/_posts/2019-03-10-fokina19a.md
+++ b/_posts/2019-03-10-fokina19a.md
@@ -6,14 +6,14 @@ abstract: "While most research in Gold-style learning focuses on learning formal
   pairs of elements of a structure are related and which are not. The aim of the learner
   is to find (an effective description of) the isomorphism type of the structure presented
   in the limit. In accordance with language learning we call this learning criterion
-  $\mathbf{InfEx}$-learning (explanatory learning from informant).\r Our main contribution
-  is a complete characterization of which families of equivalence structures are  $\mathbf{InfEx}$-learnable.
-  This characterization allows us to derive a bound of $\mathbf{0”}$ on the computational
+  $\\mathbf{InfEx}$-learning (explanatory learning from informant).\r Our main contribution
+  is a complete characterization of which families of equivalence structures are  $\\mathbf{InfEx}$-learnable.
+  This characterization allows us to derive a bound of $\\mathbf{0”}$ on the computational
   complexity required to learn uniformly enumerable families  of equivalence structures.
-  We also investigate variants of $\mathbf{InfEx}$-learning, including learning from text
+  We also investigate variants of $\\mathbf{InfEx}$-learning, including learning from text
   (where the only information provided is which elements are related, and not which
   elements are not related) and finite learning (where the first actual conjecture
-  of the learner has to be correct).\r Finally, we show how learning families of
+  of the learner has to be correct). \r Finally, we show how learning families of
   structures relates to learning classes of languages by mapping learning tasks for
   structures to equivalent learning tasks for languages."
 layout: inproceedings


### PR DESCRIPTION
I had removed the double backslash from some latex code in the abstract for _posts/2010-03-09-fokina10a.md, e.g. $\\mathbf{InfEx}$ --> $\mathbf{InfEx}$. That seems to have caused the HTML rendering to break. I re-added the double backslashes in an effort to fix this problem.