### PR TITLE
Update 2019-03-10-abou-moustafa19a.md

### DIFF
--- a/_posts/2019-03-10-abou-moustafa19a.md
+++ b/_posts/2019-03-10-abou-moustafa19a.md
@@ -1,5 +1,5 @@
 ---
-title: An Exponential Tail bound for Lq Stable Learning Rules
+title: An Exponential Efron-Stein Inequality for Lq Stable Learning Rules
 abstract: "There is an accumulating evidence in the literature that \\emph{stability
   of learning algorithms} is a key characteristic that permits a learning algorithm
   to generalize. Despite various insightful results in this direction, there seems
@@ -28,7 +28,7 @@ layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: abou-moustafa19a
 month: 0
-tex_title: An Exponential Tail bound for Lq Stable Learning Rules
+tex_title: An Exponential Efron-Stein Inequality for Lq Stable Learning Rules
 firstpage: 31
 lastpage: 63
 page: 31-63


### PR DESCRIPTION
The paper title in the PDF file is the correct title: "An Exponential Efron-Stein Inequality for Lq Stable Learning Rules". 
The current title on the PMLR website is showing a different one: "An Exponential Tail bound for Lq Stable Learning Rules".  
We will appreciate it if you can change the PMLR website title to be consistent with the actual title for the paper.